### PR TITLE
Twitter pred model

### DIFF
--- a/src/R/fit_deaths_only.R
+++ b/src/R/fit_deaths_only.R
@@ -1,5 +1,6 @@
 library(cmdstanr)
 library(dplyr)
+library(magrittr)
 library(here)
 library(readr)
 
@@ -12,16 +13,22 @@ model <- cmdstan_model(here("src", "stan", "deaths_only.stan"))
 # Real data
 br <- read_csv(here("data", "brazil_nation_2020.csv"))
 
+# Removing last 10 days of the year since it is very unusual
+br %<>%
+  filter(date <= "2020-12-20")
+
 no_days <- br %>% nrow
 population <- br %>% pull(estimated_population_2019) %>% max
 new_deaths <- br %>% pull(new_deaths)
+weeks_to_predict <- 2
 
 stan_data <- list(
   no_days = no_days,
   population = population,
   new_deaths = new_deaths,
   likelihood = 1,
-  beta_regularization = 0.10
+  beta_regularization = 0.10,
+  weeks_to_predict = weeks_to_predict
 )
 
 fit <- model$sample(data = stan_data,

--- a/src/R/loo_compare.R
+++ b/src/R/loo_compare.R
@@ -3,15 +3,18 @@ library(dplyr)
 library(here)
 library(loo)
 library(rstan)
-
-deaths_only <- list.files(here("results", "deaths_only"), full.names = TRUE) %>%
-    as_cmdstan_fit()
-rstan_deaths_only <- list.files(here("results", "deaths_only"), full.names = TRUE) %>%
-    read_stan_csv()
-twitter_deaths <- list.files(here("results", "twitter_deaths"), full.names = TRUE) %>%
-    as_cmdstan_fit()
-rstan_twitter_deaths <- list.files(here("results", "twitter_deaths"), full.names = TRUE) %>%
-    read_stan_csv()
+deaths_only <- list.files(here("results", "deaths_only"),
+                               full.names = TRUE) %>%
+        as_cmdstan_fit()
+rstan_deaths_only <- list.files(here("results", "deaths_only"),
+                                     full.names = TRUE) %>%
+        read_stan_csv()
+twitter_deaths <- list.files(here("results", "twitter_deaths"),
+                                  full.names = TRUE) %>%
+        as_cmdstan_fit()
+rstan_twitter_deaths <- list.files(here("results", "twitter_deaths"),
+                                        full.names = TRUE) %>%
+        read_stan_csv()
 
 # LOO-CV
 # Extract pointwise log-likelihood
@@ -20,11 +23,16 @@ rstan_twitter_deaths <- list.files(here("results", "twitter_deaths"), full.names
 log_lik_deaths_only <- extract_log_lik(rstan_deaths_only, merge_chains = FALSE)
 r_eff_deaths_only <- relative_eff(exp(log_lik_deaths_only), cores = 2)
 
-log_lik_twitter_deaths <- extract_log_lik(rstan_twitter_deaths, merge_chains = FALSE)
+log_lik_twitter_deaths <- extract_log_lik(rstan_twitter_deaths,
+                                          merge_chains = FALSE)
 r_eff_twitter_deaths <- relative_eff(exp(log_lik_twitter_deaths), cores = 2)
 
-loo_deaths_only <- loo(log_lik_deaths_only, r_eff = r_eff_deaths_only, cores = 2)
-loo_twitter_deaths <- loo(log_lik_twitter_deaths, r_eff = r_eff_twitter_deaths, cores = 2)
+loo_deaths_only <- loo(log_lik_deaths_only,
+                       r_eff = r_eff_deaths_only,
+                       cores = 2)
+loo_twitter_deaths <- loo(log_lik_twitter_deaths,
+                          r_eff = r_eff_twitter_deaths,
+                          cores = 2)
 
 # Compare Models
 comp <- loo_compare(loo_deaths_only, loo_twitter_deaths)

--- a/src/R/predictions_analysis.R
+++ b/src/R/predictions_analysis.R
@@ -1,0 +1,58 @@
+library(cmdstanr)
+library(rstan)
+library(dplyr)
+library(readr)
+library(tibble)
+library(here)
+
+deaths_only <- list.files(here("results", "deaths_only"),
+                               full.names = TRUE) %>%
+        as_cmdstan_fit()
+rstan_deaths_only <- list.files(here("results", "deaths_only"),
+                                     full.names = TRUE) %>%
+        read_stan_csv()
+twitter_deaths <- list.files(here("results", "twitter_deaths"),
+                                  full.names = TRUE) %>%
+        as_cmdstan_fit()
+rstan_twitter_deaths <- list.files(here("results", "twitter_deaths"),
+                                        full.names = TRUE) %>%
+        read_stan_csv()
+
+pred_deaths_only <- deaths_only$summary("pred_weekly_deaths")
+pred_twitter_deaths <- twitter_deaths$summary("pred_weekly_deaths")
+
+# Real data
+br <- read_csv(here("data", "brazil_nation_2020.csv")) %>%
+  filter(date <= "2020-12-20")
+
+real_deaths <- br %>%
+  group_by(week = cut(date, "week")) %>%
+  summarise(deaths = sum(new_deaths)) %>%
+  pull(deaths) %>%
+  ceiling %>%
+  as.integer %>%
+  enframe(name = "week", value = "real_deaths")
+
+# MAE Real vs Predicted Deaths Only
+# Last week only
+pred_deaths_only %>%
+  bind_cols(real_deaths) %>%
+  tail(1) %>%
+  mutate(
+    MAE_median = abs(median - real_deaths),
+    MAE_mean = abs(mean - real_deaths)) %>%
+  summarise(
+    MAE_median = mean(MAE_median),
+    MAE_mean = mean(MAE_mean))
+
+# MAE Real vs Predicted Deaths Twitter
+# Last week only
+pred_twitter_deaths %>%
+  bind_cols(real_deaths) %>%
+  tail(1) %>%
+  mutate(
+    MAE_median = abs(median - real_deaths),
+    MAE_mean = abs(mean - real_deaths)) %>%
+  summarise(
+    MAE_median = mean(MAE_median),
+    MAE_mean = mean(MAE_mean))

--- a/src/stan/deaths_only.stan
+++ b/src/stan/deaths_only.stan
@@ -115,7 +115,8 @@ generated quantities {
   pred_daily_deaths = neg_binomial_2_rng(daily_deaths,
                                          1 / reciprocal_phi_deaths);
   for (i in 1:weeks_to_predict){
-    log_lik[i] = neg_binomial_2_lpmf(new_weekly_deaths[i] | weekly_deaths[i],
-      1/reciprocal_phi_deaths);
+    log_lik[i] = neg_binomial_2_lpmf(new_weekly_deaths[no_weeks - weeks_to_predict + i] |
+                                         weekly_deaths[no_weeks - weeks_to_predict + i],
+                                     1/reciprocal_phi_deaths);
   }
 }

--- a/src/stan/deaths_only.stan
+++ b/src/stan/deaths_only.stan
@@ -5,6 +5,8 @@ data {
   array[no_days] int new_deaths;
   int likelihood;
   real beta_regularization;
+  // how many weeks to predict from the ODE system with no likelihood
+  int weeks_to_predict;
 }
 transformed data {
   int no_weeks = no_days %/% 7 + min(1, no_days % 7);
@@ -97,21 +99,23 @@ model {
   omega ~ beta(100, 9803);
   reciprocal_phi_deaths ~ exponential(5);
   if (likelihood) {
-    new_weekly_deaths ~ neg_binomial_2(weekly_deaths,
-                                       1 / reciprocal_phi_deaths);
+    new_weekly_deaths[: no_weeks - weeks_to_predict] ~ neg_binomial_2(
+        weekly_deaths[: no_weeks - weeks_to_predict],
+        1 / reciprocal_phi_deaths);
   }
 }
 generated quantities {
   array[no_weeks] int pred_weekly_deaths;
   array[no_days] int pred_daily_deaths;
-  vector[no_weeks] log_lik;
+  // log_lik of only weeks to predict
+  vector[weeks_to_predict] log_lik;
 
   pred_weekly_deaths = neg_binomial_2_rng(weekly_deaths,
                                           1 / reciprocal_phi_deaths);
   pred_daily_deaths = neg_binomial_2_rng(daily_deaths,
                                          1 / reciprocal_phi_deaths);
-  for (i in 1 : no_weeks) {
-    log_lik[i] = neg_binomial_2_lpmf(new_weekly_deaths[i] | weekly_deaths[i], 1
-                                                                    / reciprocal_phi_deaths);
+  for (i in 1:weeks_to_predict){
+    log_lik[i] = neg_binomial_2_lpmf(new_weekly_deaths[i] | weekly_deaths[i],
+      1/reciprocal_phi_deaths);
   }
 }

--- a/src/stan/twitter_deaths.stan
+++ b/src/stan/twitter_deaths.stan
@@ -7,6 +7,8 @@ data {
   array[no_days] int new_tweets;
   int likelihood;
   real beta_regularization;
+  // how many weeks to predict from the ODE system with no likelihood
+  int weeks_to_predict;
 }
 transformed data {
   int no_weeks = no_days %/% 7 + min(1, no_days % 7);
@@ -113,11 +115,11 @@ model {
   omega ~ beta(100, 9803);
   reciprocal_phi_deaths ~ exponential(5);
   reciprocal_phi_tweets ~ exponential(5);
-  tweet_rate ~ beta(1,3);
+  tweet_rate ~ beta(1, 1000);
   if (likelihood){
-    new_weekly_deaths ~ neg_binomial_2(
-        weekly_deaths, 1/reciprocal_phi_deaths
-    );
+    new_weekly_deaths[: no_weeks - weeks_to_predict] ~ neg_binomial_2(
+        weekly_deaths[: no_weeks - weeks_to_predict],
+        1 / reciprocal_phi_deaths);
     new_weekly_tweets ~ neg_binomial_2(
         weekly_state_I * tweet_rate, 1/reciprocal_phi_tweets
     );
@@ -128,7 +130,8 @@ generated quantities {
   array[no_weeks] int pred_weekly_deaths;
   array[no_days] int pred_daily_tweets;
   array[no_weeks] int pred_weekly_tweets;
-  vector[no_weeks] log_lik;
+  // log_lik of only weeks to predict
+  vector[weeks_to_predict] log_lik;
 
   pred_weekly_deaths = neg_binomial_2_rng(
       weekly_deaths, 1/reciprocal_phi_deaths
@@ -142,7 +145,7 @@ generated quantities {
   pred_daily_tweets = neg_binomial_2_rng(
       state_I * tweet_rate, 1/reciprocal_phi_tweets
     );
-  for (i in 1:no_weeks){
+  for (i in 1:weeks_to_predict){
     log_lik[i] = neg_binomial_2_lpmf(new_weekly_deaths[i] | weekly_deaths[i],
       1/reciprocal_phi_deaths);
   }

--- a/src/stan/twitter_deaths.stan
+++ b/src/stan/twitter_deaths.stan
@@ -146,8 +146,9 @@ generated quantities {
       state_I * tweet_rate, 1/reciprocal_phi_tweets
     );
   for (i in 1:weeks_to_predict){
-    log_lik[i] = neg_binomial_2_lpmf(new_weekly_deaths[i] | weekly_deaths[i],
-      1/reciprocal_phi_deaths);
+    log_lik[i] = neg_binomial_2_lpmf(new_weekly_deaths[no_weeks - weeks_to_predict + i] |
+                                         weekly_deaths[no_weeks - weeks_to_predict + i],
+                                     1/reciprocal_phi_deaths);
   }
 }
 


### PR DESCRIPTION
This removes the last 2 weeks of weekly deaths from the likelihood but uses those weeks as the loglikelihood for model comparison.


## Results

The model are similar in loglikelihood LOO-CV:

```r
[1] "LOO: Deaths Only(1) vs Twitter + Deaths(2)"
       elpd_diff se_diff  elpd_loo se_elpd_loo p_loo    se_p_loo looic    se_looic
model2    0.000     0.000  -19.263    0.068       0.022    0.000   38.526    0.135
model1 -119.307    90.083 -138.570   90.151     122.812   88.963  277.140  180.302
```

But the Twitter + Deaths(2) has a MAE for the predicted last 2 weeks of **`1185`**,
while the Deaths Only(1) has a MAE of **`1360`**.

---

Also closes #1
